### PR TITLE
Allow for augmentation of text input styles in BB7

### DIFF
--- a/pkg/bbUI.js
+++ b/pkg/bbUI.js
@@ -1228,8 +1228,9 @@ bb.textInput = {
             }
         } else {
             for (var i = 0; i < elements.length; i++) {
-                var outerElement = elements[i],
-                    style = 'bb-bb7-input';
+                var outerElement = elements[i];
+                var style = outerElement.getAttribute('class');
+                style = style + ' bb-bb7-input';
                 
                 if (bb.device.isHiRes) {
                     style = style + ' bb-bb7-input-hires';

--- a/samples/bbUI.js
+++ b/samples/bbUI.js
@@ -1228,8 +1228,9 @@ bb.textInput = {
             }
         } else {
             for (var i = 0; i < elements.length; i++) {
-                var outerElement = elements[i],
-                    style = 'bb-bb7-input';
+                var outerElement = elements[i];
+                var style = outerElement.getAttribute('class');
+                style = style + ' bb-bb7-input';
                 
                 if (bb.device.isHiRes) {
                     style = style + ' bb-bb7-input-hires';

--- a/src/plugins/textInput.js
+++ b/src/plugins/textInput.js
@@ -6,8 +6,9 @@ bb.textInput = {
             }
         } else {
             for (var i = 0; i < elements.length; i++) {
-                var outerElement = elements[i],
-                    style = 'bb-bb7-input';
+                var outerElement = elements[i];
+                var style = outerElement.getAttribute('class');
+                style = style + ' bb-bb7-input';
                 
                 if (bb.device.isHiRes) {
                     style = style + ' bb-bb7-input-hires';


### PR DESCRIPTION
I wanted to make a larger input field with stylized text but was unable to since the textInput plugin wipes the css styles.

This change will recognize styles applied by the dev but still allow the BB7 styles to override. The dev, if desired, can then override the BB7 style by including the !important flag.
