### PR TITLE
jake - first run fix

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -66,6 +66,7 @@ task('build', ['clean'], function () {
     });
 	
 	// Write our our JS files
+    fs.mkdirSync(__dirname + '/pkg');
     fs.writeFileSync(__dirname + "/pkg/bbui.js", license + output);
     fs.writeFileSync(__dirname + "/samples/bbui.js", license + output);
 


### PR DESCRIPTION
I got this error when I first ran jake.

$ jake
Gathering Files...
jake aborted.
Error: ENOENT, no such file or directory '\github\bbUI.js\pkg\bbui.js'
    at Object.fs.openSync (fs.js:338:18)
(See full trace by running task with --trace)
