### PR TITLE
Fixed undefined variable error in image list headers on Playbook

### DIFF
--- a/src/plugins/_bbPlayBook_imageList.js
+++ b/src/plugins/_bbPlayBook_imageList.js
@@ -1,6 +1,7 @@
 _bbPlayBook_imageList = {  
     apply: function(elements) {
-		var i,j,
+		var res = (bb.device.isPlayBook) ? 'lowres' : 'hires',
+			i,j,
 			outerElement,
 			items;
 				


### PR DESCRIPTION
The var "res" used in center aligned header code was not defined.
