### PR TITLE
Issue #615 Fix -Titlebar with only one button has text out-of-place

### DIFF
--- a/samples/bbui.js
+++ b/samples/bbui.js
@@ -4636,13 +4636,13 @@ bb.titleBar = {
 										} 
 										//Set margins for title bar caption when only an action button is present
 										else if (this.actionButton) {
-											this.caption.style['margin-left'] = '0px';
-											this.caption.style['margin-right'] = '0px';
+											this.caption.style['margin-left'] = (actionWidth+24) +'px';
+											this.caption.style['margin-right'] = (actionWidth+24) +'px';
 										} 
 										//Set margins for title bar caption when only a back button is present
 										else if (this.backButton) {
-											this.caption.style['margin-right'] = '0px';
-											this.caption.style['margin-left'] =  '0px';
+											this.caption.style['margin-right'] = (backWidth + 24) +'px';
+											this.caption.style['margin-left'] =  (backWidth + 24) +'px';
 										}
 									};
 				titleBar.evenButtonWidths = titleBar.evenButtonWidths.bind(titleBar);

--- a/src/plugins/titleBar.js
+++ b/src/plugins/titleBar.js
@@ -89,13 +89,13 @@ bb.titleBar = {
 										} 
 										//Set margins for title bar caption when only an action button is present
 										else if (this.actionButton) {
-											this.caption.style['margin-left'] = '0px';
-											this.caption.style['margin-right'] = '0px';
+											this.caption.style['margin-left'] = (actionWidth+24) +'px';
+											this.caption.style['margin-right'] = (actionWidth+24) +'px';
 										} 
 										//Set margins for title bar caption when only a back button is present
 										else if (this.backButton) {
-											this.caption.style['margin-right'] = '0px';
-											this.caption.style['margin-left'] =  '0px';
+											this.caption.style['margin-right'] = (backWidth + 24) +'px';
+											this.caption.style['margin-left'] =  (backWidth + 24) +'px';
 										}
 									};
 				titleBar.evenButtonWidths = titleBar.evenButtonWidths.bind(titleBar);


### PR DESCRIPTION
Authors (github usernames)
@haixuanc
@williekwok

Changed the margin addition to 0px for title bar caption when there is only one button (either the back button or action button). 

Tested in both simulator and device
![Screen Shot 2013-01-19 at 10 34 16 AM](https://f.cloud.github.com/assets/1329555/80517/33b68e66-6267-11e2-88d8-4ecd62a7b5f7.png)
![Screen Shot 2013-01-19 at 10 35 07 AM](https://f.cloud.github.com/assets/1329555/80518/33c7eb3e-6267-11e2-91ed-b80a3f9eaa39.png)
