### PR TITLE
Issue #558 - Fix to use overflow ellipsis for text overflow in image lists

### DIFF
--- a/samples/bbui.css
+++ b/samples/bbui.css
@@ -3071,7 +3071,7 @@ a.bb5-button-highlight span {
 	font-size: 26pt;	
 	margin-bottom: 0px;
 	margin-top:-1px;
-	text-overflow: -blackberry-fade;
+	text-overflow: ellipsis;
 }
 
 .bb-bb10-image-list-item-1280x768-1280x720 .accent-text

--- a/src/bbUI.css
+++ b/src/bbUI.css
@@ -3053,7 +3053,7 @@ a.bb5-button-highlight span {
 	font-size: 26pt;	
 	margin-bottom: 0px;
 	margin-top:-1px;
-	text-overflow: -blackberry-fade;
+	text-overflow: ellipsis;
 }
 
 .bb-bb10-image-list-item-1280x768-1280x720 .accent-text


### PR DESCRIPTION
@williekwok
Tested on Ripple and Dev Alpha B

Before:
![Screen Shot 2013-01-19 at 4 11 19 PM](https://f.cloud.github.com/assets/1329555/80779/8fc0d19c-629b-11e2-9659-bdb7075ee1bc.png)
After:
![Screen Shot 2013-01-19 at 4 15 01 PM](https://f.cloud.github.com/assets/1329555/80780/8fd1d924-629b-11e2-9743-2607d87c0b15.png)
