### PR TITLE
Issue #624 - Truncate the titlebar button's text when it overflows

### DIFF
--- a/samples/bbui.css
+++ b/samples/bbui.css
@@ -2045,6 +2045,8 @@ body, html {
 	border-radius:10px;
 	padding: 4px;
 	margin: 15px;
+	/* Set the max width to 100% for the titlebar button */
+	max-width: 100%;
 }  
 
 .bb-bb10-titlebar-button-1280x768-1280x720 {
@@ -2056,6 +2058,11 @@ body, html {
 	padding-left: 35px;
 	padding-right: 35px;
 	font-size:28pt;
+	/* Truncate the titlebar button's text when it overflows */
+	overflow: hidden;
+    white-space:nowrap;
+    text-overflow: ellipsis;
+    text-overflow: -blackberry-fade;
 }
 
 /* ================================================= 

--- a/src/bbUI.css
+++ b/src/bbUI.css
@@ -2027,6 +2027,8 @@ body, html {
 	border-radius:10px;
 	padding: 4px;
 	margin: 15px;
+	/* Set the max width to 100% for the titlebar button */
+	max-width: 100%;
 }  
 
 .bb-bb10-titlebar-button-1280x768-1280x720 {
@@ -2038,6 +2040,11 @@ body, html {
 	padding-left: 35px;
 	padding-right: 35px;
 	font-size:28pt;
+	/* Truncate the titlebar button's text when it overflows */
+	overflow: hidden;
+    white-space:nowrap;
+    text-overflow: ellipsis;
+    text-overflow: -blackberry-fade;
 }
 
 /* ================================================= 


### PR DESCRIPTION
The original issue is: if the titlebar button's text is too long, the text will span beyond the screen. Here is the screenshot:
![image](https://f.cloud.github.com/assets/1450914/81448/c7a5b3f2-632c-11e2-9d63-12cd4f4379e3.png)
And here is the screenshot of the fix:
![image](https://f.cloud.github.com/assets/1450914/81449/e3f19bb6-632c-11e2-8ab1-6f1ae547815b.png)
