### PR TITLE
Adding package.json file for easier initial setup

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,19 +8,15 @@ or follow the installation guide [here][2]
 Building is done with [jake][3], JavaScript minifying is done with [Uglify-js](https://github.com/mishoo/UglifyJS) and CSS 
 minifying is done with [CleanCSS](https://github.com/GoalSmashers/clean-css). 
 
-Jake can be installed using npm with:
+If you don't already have Jake installed, first install it using npm with:
 
     npm install -g jake
     
-Uglify-JS can be installed using npm with:
+Next, ensure you're in the root directory of the project then install development dependencies with:
 
-    npm install uglify-js
+    npm install
     
-CleanCSS can be installed using npm with:
-
-    npm install clean-css
-
-and to build bbUI.js you just navigate to the bbUI.js directory via a command line and run:
+Finally, build bbUI.js:
 
     jake
 

--- a/Jakefile
+++ b/Jakefile
@@ -53,6 +53,9 @@ task('build', ['clean'], function () {
 	version = JSON.parse(include("JakeVersion"));
 	version.build++;
 	versionText = '/* VERSION: ' + version.major + '.' + version.minor + '.' + version.revision + '.' + version.build + '*/\n\n';
+
+	pkg = JSON.parse(include("package.json"));
+	pkg.version = version.major + '.' + version.minor + '.' + version.revision;
 	
 	// Retrieve our license information
 	license = include("JakeLicense");
@@ -85,8 +88,10 @@ task('build', ['clean'], function () {
 	fs.writeFileSync(__dirname + "/pkg/bbui-min.css", license + minified);
 	
 	// Update our build version
-	versionText = '{"major" : ' + version.major +',	"minor" : ' + version.minor +', "revision" : ' + version.revision + ', "build" : '+ version.build+'}';
-	fs.writeFileSync("JakeVersion", versionText);
+	fs.writeFileSync("JakeVersion", JSON.stringify(version, undefined, 2));
+
+	// Update the build version in the npm package.json
+	fs.writeFileSync("package.json", JSON.stringify(pkg, undefined, 2));
 
     console.log("Holy Chetara Batman, That was fast!");
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bbUI.js",
+  "description": "Common HTML5/Javascript UI constructs for BlackBerry WebWorks applications",
+  "version": "0.9.6",
+  "author": {
+    "name": "Tim Neil",
+    "email": "tneil@rim.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blackberry/bbUI.js.git"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "clean-css": "0.9.x",
+    "uglify-js": "2.2.x"
+  }
+}


### PR DESCRIPTION
@fredericosilva proposed adding a package.json file a few months ago, which is a good idea, so this patch adds one.

Use `npm install` to install build dependencies (ugligy-js and clean-css) instead of installing each one individually.
