### PR TITLE
Context menu shows up on scrolling

### DIFF
--- a/pkg/bbui.js
+++ b/pkg/bbui.js
@@ -2406,7 +2406,6 @@ bb.menuBar = {
 					if (type == 'menu-item') {
 						caption = item.innerHTML;
 						imgPath = item.getAttribute('data-bb-img');
-						useid = item.getAttribute('data-bb-useid');
 						// If the item doesn't have both an image and text then remove it
 						if ((caption && imgPath) && (foundItems.length < 5)) {
 							// BB10 menus only allow 5 items max
@@ -2424,10 +2423,7 @@ bb.menuBar = {
 							div.setAttribute('class','bb-bb10-menu-bar-item-caption-'+res);
 							div.innerHTML = caption;
 							bb10MenuItem.appendChild(div);
-							// Set the menu ID if specified so we can play around with it later
-							if(useid){
-								bb10MenuItem.setAttribute('id',useid);
-							}
+							
 							// Assign any click handlers
 							bb10MenuItem.onclick	= item.onclick;
 							bb10Menu.appendChild(bb10MenuItem);
@@ -5683,6 +5679,8 @@ _bb10_imageList = {
 														innerChildNode.contextShown = false;
 														if (innerChildNode.contextMenu) {
 															window.setTimeout(this.touchTimer, 667);
+															var scr = bb.getCurScreen();
+															innerChildNode.touchstartx = scr.bbUIscrollWrapper.scrollTop;
 														}
 													};
 						innerChildNode.ontouchend = function (event) {
@@ -5695,7 +5693,9 @@ _bb10_imageList = {
 														}
 													};
 						innerChildNode.touchTimer = function() {
-														if (innerChildNode.fingerDown) {
+														var scr = bb.getCurScreen();
+														var curx = scr.bbUIscrollWrapper.scrollTop;
+														if (innerChildNode.fingerDown && Math.abs(innerChildNode.touchstartx - curx) < 50) {
 															innerChildNode.contextShown = true;
 															this.setAttribute('class',this.highlight);
 															this.overlay.style['border-color'] =  bb.options.shades.darkOutline;


### PR DESCRIPTION
Context menu
- Fixes context menu showing up when scrolling on image list and image grid (temporary fix until move
  to native webworks is complete)
- Adds function bb.getCurScreen to get the current screen element
- Fixes some things mentioned in #370
