### PR TITLE
application menu update

### DIFF
--- a/src/bbUI.css
+++ b/src/bbUI.css
@@ -834,7 +834,23 @@ body, html {
     display: inline-block;
 }
 
-   
+/* ================================================= 
+   BB10 Swipe Menu 
+   =================================================*/
+.bb-bb10-menu-bar-overlay 
+{
+	z-index: 1000;
+	position: fixed;
+	top: 0px;
+	right:0px;
+	bottom:0px;
+	left:0px;
+	display:none;
+	background-color:black;
+	opacity:0.25;
+}
+
+
 /* ================================================= 
    BB10 Swipe Menu 1024x600
    =================================================*/

--- a/src/plugins/_PlayBook_contextMenu.js
+++ b/src/plugins/_PlayBook_contextMenu.js
@@ -123,6 +123,11 @@ _PlayBook_contextMenu = {
 						this.header.addEventListener("click", this.hide, false);
 						this.style.visibility = 'visible';
 						this.visible = true;
+						if(bb.device.isPlayBook){
+							blackberry.app.event.onSwipeDown('');
+						} else {
+							blackberry.event.removeEventListener("swipedown", bb.menuBar.showMenuBar);
+						}
 					};
 		menu.show = menu.show.bind(menu);
 		// Hide the menu
@@ -159,7 +164,12 @@ _PlayBook_contextMenu = {
 							for (var i = 0; i < this.actions.length; i++) {
 								this.actions[i].ontouchend();
 							}
-						}						
+						}
+						if(bb.device.isPlayBook){
+							blackberry.app.event.onSwipeDown(bb.menuBar.showMenuBar);
+						} else {
+							blackberry.event.addEventListener("swipedown", bb.menuBar.showMenuBar);
+						}
 					};
 		menu.hide = menu.hide.bind(menu);
 		// Peek the menu
@@ -199,6 +209,11 @@ _PlayBook_contextMenu = {
 						this.header.removeEventListener("click", this.hide, false);		
 						this.style.visibility = 'visible';
 						this.visible = true;
+						if(bb.device.isPlayBook){
+							blackberry.app.event.onSwipeDown('');
+						} else {
+							blackberry.event.removeEventListener("swipedown", bb.menuBar.showMenuBar);
+						}
 					};
 		menu.peek = menu.peek.bind(menu);
 		

--- a/src/plugins/_bb10_contextMenu.js
+++ b/src/plugins/_bb10_contextMenu.js
@@ -41,7 +41,7 @@ _bb10_contextMenu = {
 							selected : node
 						};
 				}
-				
+				blackberry.event.removeEventListener("swipedown", bb.menuBar.showMenuBar);				
 			};
 		menu.oncontextmenu = menu.oncontextmenu.bind(menu);
 		window.addEventListener('contextmenu', menu.oncontextmenu);
@@ -52,6 +52,7 @@ _bb10_contextMenu = {
 				if (this.selected && this.selected.selected) {
 					this.selected.selected.drawUnselected();
 				}
+				blackberry.event.addEventListener("swipedown", bb.menuBar.showMenuBar);
 			};
 		menu.oncontextmenuclosed = menu.oncontextmenuclosed.bind(menu);
 		document.addEventListener('bbui.contextClosed', menu.oncontextmenuclosed);

--- a/src/plugins/menuBar.js
+++ b/src/plugins/menuBar.js
@@ -1,7 +1,8 @@
 bb.menuBar = {
-	height: 100,
+	height: 140,
 	menuOpen: false,
 	menu: false,
+	screen: false,
 
 	apply: function(menuBar,screen){
 		if (bb.device.isPlayBook || bb.device.isBB10) {
@@ -53,12 +54,17 @@ bb.menuBar = {
 	createSwipeMenu: function(menuBar, screen){
 		// Get our resolution text for BB10 styling			
 		if (bb.device.isBB10) {
+			bb.menuBar.screen = screen;
 			var bb10Menu = document.createElement('div'),
 				res = '1280x768-1280x720',
+				maxItems = 5,
 				i,
+				len,
 				type,
 				item,
-				foundItems = [],
+				pinLeft = false,
+				pinRight = false,
+				menuItems = [],
 				img,
 				imgPath,
 				caption,
@@ -81,58 +87,85 @@ bb.menuBar = {
 			bb10Menu.setAttribute('class','bb-bb10-menu-bar-'+res+' bb-bb10-menu-bar-dark');
 			items = menuBar.querySelectorAll('[data-bb-type=menu-item]');
 			if(items.length > 0){
-				for (i = 0; i < items.length; i++) {
+				//pre-process and collect valid menu items + identify pinned items
+				for(i = 0, len = items.length; i < items.length; i++){
 					item = items[i];
 					type = item.hasAttribute('data-bb-type') ? item.getAttribute('data-bb-type').toLowerCase() : undefined;
 					// Get our menu items
 					if (type == 'menu-item') {
 						caption = item.innerHTML;
 						imgPath = item.getAttribute('data-bb-img');
-						// If the item doesn't have both an image and text then remove it
-						if ((caption && imgPath) && (foundItems.length < 5)) {
-							// BB10 menus only allow 5 items max
-							bb10MenuItem = document.createElement("div");
-							foundItems.push(bb10MenuItem);
-							// Set our item information
-							bb10MenuItem.setAttribute('class','bb-bb10-menu-bar-item-'+res);
-							item.innerHTML = '';
-							// Add the image
-							img = document.createElement('img');
-							img.setAttribute('src',imgPath);
-							bb10MenuItem.appendChild(img);
-							// Add the caption
-							div = document.createElement('div');
-							div.setAttribute('class','bb-bb10-menu-bar-item-caption-'+res);
-							div.innerHTML = caption;
-							bb10MenuItem.appendChild(div);
-
-							// Assign any click handlers
-							bb10MenuItem.onclick	= item.onclick;
-							bb10Menu.appendChild(bb10MenuItem);
-						} else {
-							if(foundItems.length >= 5){
-								console.log('too many menu items.');
+						if (caption && imgPath) {
+							if(item.hasAttribute('data-bb-pin')){
+								pinType = item.getAttribute('data-bb-pin').toLowerCase();
+								if(pinType === 'left' && !pinLeft){
+									pinLeft = item;
+									maxItems--;
+								} else if(pinType === 'right' && !pinRight){
+									pinRight = item;
+									maxItems--;
+								} else {
+									console.log('Unknown value from menu-item data-bb-pin: ' + pinType + ' or value already defined.');
+									menuItems.push(item); //add to the regular menu array
+								}
 							} else {
-								console.log('missing menu item caption or image.');
+								menuItems.push(item);
 							}
+						} else {
+							console.log('missing menu item caption or image.');
 						}
 					} else {
 						console.log('invalid menu item type for bb10');
 					}
 				}
-			}
-			// Now apply the widths since we now know how many there are
-			if (foundItems.length > 0) {
-				width = Math.floor(100/foundItems.length);
-				for (i = 0; i < foundItems.length;i++) {
-					item = foundItems[i];
-					if (i == foundItems.length -1) {
-						item.style.width = width - 1 +'%';
-						item.style.float = 'right';
+
+				//trim down items if too many
+				if(menuItems.length >= maxItems){
+					menuItems = menuItems.slice(0, maxItems);
+				}
+
+				//add back left and right pinned items if they exist
+				if(pinLeft){
+					menuItems.unshift(pinLeft);
+				}
+
+				if(pinRight){
+					menuItems.push(pinRight);
+				}
+
+				//we can now figure out the width of each item
+				width = Math.floor(100/menuItems.length);
+
+				for (i = 0, len = menuItems.length; i < len; i++) {
+					item = menuItems[i];
+					caption = item.innerHTML;
+					imgPath = item.getAttribute('data-bb-img');
+
+					bb10MenuItem = document.createElement("div");
+					// Set our item information
+					bb10MenuItem.setAttribute('class','bb-bb10-menu-bar-item-'+res);
+					item.innerHTML = '';
+					// Add the image
+					img = document.createElement('img');
+					img.setAttribute('src',imgPath);
+					bb10MenuItem.appendChild(img);
+					// Add the caption
+					div = document.createElement('div');
+					div.setAttribute('class','bb-bb10-menu-bar-item-caption-'+res);
+					div.innerHTML = caption;
+					bb10MenuItem.appendChild(div);
+
+					// Assign any click handlers
+					bb10MenuItem.onclick	= item.onclick;
+					//set menu item width
+					if (i == menuItems.length -1) {
+						bb10MenuItem.style.width = width - 1 +'%';
+						bb10MenuItem.style.float = 'right';
 					} else {
-						item.style.width = width +'%';
+						bb10MenuItem.style.width = width +'%';
 					}				
-				}	
+					bb10Menu.appendChild(bb10MenuItem);
+				}
 			} else {
 				bb10Menu.style.display = 'none';
 				bb.menuBar.menu = null;
@@ -141,7 +174,7 @@ bb.menuBar = {
 			// Set the size of the menu bar and assign the lstener
 			bb10Menu.style['-webkit-transform']	= 'translate(0,0)';
 			bb10Menu.addEventListener('click', bb.menuBar.onMenuBarClicked, false);
-			document.body.appendChild(bb10Menu);
+			screen.appendChild(bb10Menu);
 			// Assign the menu
 			bb.menuBar.menu	= bb10Menu;	
 		} else {
@@ -155,6 +188,7 @@ bb.menuBar = {
 				div, 
 				br, 
 				pbMenuItem;
+			bb.menuBar.height = 100;
 			pbMenu.setAttribute('class','pb-menu-bar');
 			// See if there are any items declared
 			items = menuBar.getElementsByTagName('div');
@@ -209,7 +243,7 @@ bb.menuBar = {
 		// Add the overlay for trapping clicks on items below
 		if (!bb.screen.overlay) {
 			bb.screen.overlay = document.createElement('div');
-			bb.screen.overlay.setAttribute('class','bb-bb10-context-menu-overlay');
+			bb.screen.overlay.setAttribute('class','bb-bb10-menu-bar-overlay');
 		}
 		screen.appendChild(bb.screen.overlay);
 		bb.menuBar.menu.overlay = bb.screen.overlay;	
@@ -224,8 +258,16 @@ bb.menuBar = {
 				blackberry.event.removeEventListener("swipedown", bb.menuBar.showMenuBar);
 				blackberry.event.addEventListener("swipedown", bb.menuBar.hideMenuBar);
 			}
-			bb.menuBar.menu.style['-webkit-transition'] = 'all 0.5s ease-in-out';
-			bb.menuBar.menu.style['-webkit-transform'] = 'translate(0, ' + (bb.menuBar.height + 3) + 'px)';
+
+			//Use the right transition
+			if(bb.device.isBB10){
+				bb.menuBar.screen.style['-webkit-transition'] = 'all 0.25s ease-in-out';
+				bb.menuBar.screen.style['-webkit-transform'] = 'translate(0, ' + (bb.menuBar.height + 3) + 'px)';
+			}else if(bb.device.isPlayBook){
+				bb.menuBar.menu.style['-webkit-transition'] = 'all 0.5s ease-in-out';
+				bb.menuBar.menu.style['-webkit-transform'] = 'translate(0, ' + (bb.menuBar.height + 3) + 'px)';
+				bb.menuBar.menu.overlay.style.display = 'none';
+			}
 			bb.menuBar.menuOpen = true;
 			bb.menuBar.menu.overlay.addEventListener('touchstart', bb.menuBar.overlayTouchHandler, false);
 		}
@@ -240,8 +282,15 @@ bb.menuBar = {
 					blackberry.event.removeEventListener("swipedown", bb.menuBar.hideMenuBar);
 					blackberry.event.addEventListener("swipedown", bb.menuBar.showMenuBar);
 			}
-			bb.menuBar.menu.style['-webkit-transition'] = 'all 0.5s ease-in-out';
-			bb.menuBar.menu.style['-webkit-transform'] = 'translate(0, -' + (bb.menuBar.height + 3) + 'px)';
+			//Use the right transition
+			if(bb.device.isBB10){
+				bb.menuBar.screen.style['-webkit-transition'] = 'all 0.25s ease-in-out';
+				bb.menuBar.screen.style['-webkit-transform'] = 'translate(0, 0)';
+				bb.menuBar.menu.overlay.style.display = 'none';
+			}else if(bb.device.isPlayBook){
+				bb.menuBar.menu.style['-webkit-transition'] = 'all 0.5s ease-in-out';
+				bb.menuBar.menu.style['-webkit-transform'] = 'translate(0, -' + (bb.menuBar.height + 3) + 'px)';
+			}
 			bb.menuBar.menuOpen = false;
 			bb.menuBar.menu.overlay.removeEventListener('touchstart', bb.menuBar.overlayTouchHandler, false);
 		}

--- a/src/plugins/screen.js
+++ b/src/plugins/screen.js
@@ -33,14 +33,10 @@ bb.screen = {
 			outerElement.setAttribute('class', screenRes);
             		
 			//check to see if a menu/menuBar needs to be created
-			var menuBar = outerElement.querySelectorAll('[data-bb-type=menu]');
-			if (menuBar.length > 0) {
-				menuBar = menuBar[0];
-				bb.menuBar.apply(menuBar,outerElement);
-			}
            
             if (bb.device.isBB10) {
-                var titleBar = outerElement.querySelectorAll('[data-bb-type=title]'),
+				var menuBar = outerElement.querySelectorAll('[data-bb-type=menu]');
+                	titleBar = outerElement.querySelectorAll('[data-bb-type=title]'),
 					actionBar = outerElement.querySelectorAll('[data-bb-type=action-bar]'),
 					context = outerElement.querySelectorAll('[data-bb-type=context-menu]'),
 					outerScrollArea,
@@ -48,9 +44,16 @@ bb.screen = {
 					tempHolder = [],
 					childNode = null, 
 					j,
+					menuBarHeight = bb.screen.getMenuBarHeight(),
 					actionBarHeight = bb.screen.getActionBarHeight(),
 					titleBarHeight = bb.screen.getTitleBarHeight();
 				
+				if (menuBar.length > 0) {
+					menuBar = menuBar[0];
+					outerElement.menuBar = menuBar;
+				}else{
+					menuBar = null;
+				}
 				// Figure out what to do with the title bar
                 if (titleBar.length > 0) {
 					titleBar = titleBar[0];
@@ -92,6 +95,7 @@ bb.screen = {
 				}
 				
 				// Set our variables for showing/hiding action bars
+				outerElement.menuBarHeight = menuBarHeight
 				outerElement.actionBarHeight = actionBarHeight;
 				outerElement.titleBarHeight = titleBarHeight;
 				outerElement.outerScrollArea = outerScrollArea;
@@ -192,6 +196,10 @@ bb.screen = {
 		          	outerScrollArea.style['right'] = '0px';
 				}
 				
+				if(menuBar) {
+					bb.menuBar.apply(menuBar, outerElement);
+				}
+
 				// Apply any title bar styling
 				if (titleBar) {		
 					bb.titleBar.apply(titleBar);
@@ -210,6 +218,12 @@ bb.screen = {
 				}
 			} 
 			else if (bb.device.isPlayBook) {
+				var menuBar = outerElement.querySelectorAll('[data-bb-type=menu]');
+				if (menuBar.length > 0) {
+					menuBar = menuBar[0];
+					bb.menuBar.apply(menuBar,outerElement);
+				}
+
                 var titleBar = outerElement.querySelectorAll('[data-bb-type=title]'),
 					outerScrollArea,
 					scrollArea,
@@ -276,7 +290,12 @@ bb.screen = {
 				}
             }
             else {
-                // See if there is a title bar
+				var menuBar = outerElement.querySelectorAll('[data-bb-type=menu]');
+				if (menuBar.length > 0) {
+					menuBar = menuBar[0];
+					bb.menuBar.apply(menuBar,outerElement);
+				}
+	                // See if there is a title bar
                 var titleBar = outerElement.querySelectorAll('[data-bb-type=title]'),
 					actionBar = outerElement.querySelectorAll('[data-bb-type=action-bar]'),
 					context = outerElement.querySelectorAll('[data-bb-type=context-menu]');		
@@ -516,6 +535,17 @@ bb.screen = {
             document.body.style.height = screen.height + 'px';
         }
     },
+	
+	getMenuBarHeight: function() {
+		// Set our 'res' for known resolutions, otherwise use the default
+		if (bb.device.is1024x600) {
+			return (bb.getOrientation().toLowerCase() == 'portrait') ? 73 : 73;
+		} else if (bb.device.is1280x768 || bb.device.is1280x720) {
+			return (bb.getOrientation().toLowerCase() == 'portrait') ? 140 : 111; 
+		} else {
+			return (bb.getOrientation().toLowerCase() == 'portrait') ? 140 : 111;
+		}
+	},
 	
 	getActionBarHeight: function() {
 		// Set our 'res' for known resolutions, otherwise use the default

--- a/src/plugins/tabOverflow.js
+++ b/src/plugins/tabOverflow.js
@@ -73,6 +73,11 @@ bb.tabOverflow = {
 					this.setDimensions();					
 					// Reset our overflow menu button
 					tabOverflowBtn.reset();
+					if(bb.device.isPlayBook){
+						blackberry.app.event.onSwipeDown();
+					} else {
+						blackberry.event.removeEventListener("swipedown", bb.menuBar.showMenuBar);
+					}
 				};
 		menu.show = menu.show.bind(menu);	
 		
@@ -113,6 +118,11 @@ bb.tabOverflow = {
 						tabOverflowBtn.icon.setAttribute('class',this.tabOverflowState.style);
 						tabOverflowBtn.tabHighlight.style.display = this.tabOverflowState.display;
 						tabOverflowBtn.display.innerHTML = this.tabOverflowState.caption;
+					}
+					if(bb.device.isPlayBook){
+						blackberry.app.event.onSwipeDown(bb.menuBar.showMenuBar);
+					} else {
+						blackberry.event.addEventListener("swipedown", bb.menuBar.showMenuBar);
 					}
 				};
 		menu.hide = menu.hide.bind(menu);


### PR DESCRIPTION
Code to fixes #379

Menu now behaves properly on BB10 devices, and PlayBook with the BB10 flag. It still has original behaviour for PlayBook without the BB10 flag.

I believe it behaves and looks as specified in the UI/UX document.

There are now options for:
data-bb-pin="right" - pulls this icon to the far right
data-bb-pin="left" - pulls this icon to the far left

Both of these grab the first item specified, subsequent items are treated as normal items. They are there to make it easier to place help and settings menu.

swipedown/onswipe menu is now disabled if Tab Overflow or CCM are displaying.
