### PR TITLE
Add onbackclick support for title bar to hook custom logic to the titlebar back button

### DIFF
--- a/samples/bbui.js
+++ b/samples/bbui.js
@@ -1346,10 +1346,10 @@ bb.actionBar = {
 		actionBar.setBackCaption = actionBar.setBackCaption.bind(actionBar);  
 		
 		// Add setSelectedTab function
-		actionBar.setSelectedTab = function(tab, invokeOnClick) {
+		actionBar.setSelectedTab = function(tab) {
 					if (tab.getAttribute('data-bb-style') != 'tab') return;
 					bb.actionBar.highlightAction(tab);
-					if (tab.onclick && false !== invokeOnClick) {
+					if (tab.onclick) {
 						tab.onclick();
 					}
 				};


### PR DESCRIPTION
  This commit is created to add a custom onbackclick attribute for titlebar, 

  The logic is 
- If there's no onbackclick attribute defined for the titlebar, then bb.pushScreen() will be invoked, that's the same as former behavior.
- If there's any onbackclick attribute defined for the titlebar, then the code defined in onbackclick will be invoked, like onactionclick.
  
  This request add another possibility to control the page flow, using cancel button in the titlebar.
