### PR TITLE
Fix for Issue #858

### DIFF
--- a/src/bbUI.css
+++ b/src/bbUI.css
@@ -862,7 +862,6 @@ body, html {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	top: -103px;
 	font-size: 100%;
 	z-index:1002;
 	height: 100px;


### PR DESCRIPTION
A CSS line got left in place for the Playbook menu causing it to not appear properly.
