### PR TITLE
Removed padding of menu bar item in BB10

### DIFF
--- a/src/bb10/css/bbUI.css
+++ b/src/bb10/css/bbUI.css
@@ -650,7 +650,6 @@ body, html {
 
 .bb-menu-bar-item-caption {
 	font-size: 20pt;
-	padding-top: 10px;
 	height: 31px;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
When adding captions to the items in a screen menu, the text is too low, almost getting of the menu.

![img_00000006](https://cloud.githubusercontent.com/assets/2621975/3928917/c0b47a34-2413-11e4-810b-709c9ebf3b1f.png)

In the CSS rule `.bb-menu-bar-item-caption` at [src/bb10/css/bbUI.css#L653](https://github.com/blackberry/bbUI.js/blob/master/src/bb10/css/bbUI.css#L653) the captions is given 10px of padding at the top and that is pushing the text down.

Removing the padding fixes the position of the captions:

![img_00000004](https://cloud.githubusercontent.com/assets/2621975/3928932/2cfe3b6c-2414-11e4-8968-a9b9804b5736.png)
